### PR TITLE
Add some missing bits to the documentation

### DIFF
--- a/packages/buildroot/README.md
+++ b/packages/buildroot/README.md
@@ -40,14 +40,25 @@ The goal of this build process is to produce a `filesystem` folder containing a 
 
 2. Build the `filesystem` folder:
 
-```bash
-make
-```
+    ```bash
+    make
+    ```
 
-...
+    ...
 
-At this point you can go for a walk, it will take a bit of time :turtle:
+    At this point you can go for a walk, it will take a bit of time :turtle:
 
-...
+    ...
 
-The `filesystem` folder should be available on the host at `build/filesystem`
+3. The `filesystem` folder should be available on the host at `build/filesystem`. Copy it to `packages/runtime/filesystem`:
+
+    ```bash
+    # (on the host)
+    rm -r ../runtime/filesystem/
+    cp -r build/filesystem ../runtime/
+    ```
+
+    Update the `bzimageUrl` ID in the `index.html` file of the runtime:
+    ```bash
+    jq -r '.fsroot | map(select(.[0] == "bzImage"))[0][6]' < ../runtime/filesystem/filesystem.json
+    ```

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -24,8 +24,8 @@
 
 1. Go the `http://localhost:3000?boot=true`
 
-2. Once the boot is completed, clear the cache running:
- `echo 3 > /proc/sys/vm/drop_caches && echo 3 > /proc/sys/kernel/printk && reset`
+2. Once the boot is completed, clear the cache and start psql (the runtime assumes psql is running when it loads a snapshot):
+ `echo 3 > /proc/sys/vm/drop_caches && echo 3 > /proc/sys/kernel/printk && reset && psql -U postgres`
 
 3. Save the state to a file clicking the `Save state to file` button
 


### PR DESCRIPTION
I noticed a few steps were missing when I was building a filesystem and state file.

This PR adds more documentation for copying the filesystem data, updating the `bzimageUrl`, and creating a state file.